### PR TITLE
Fix get_league_listing and return the status code 

### DIFF
--- a/R/get_league_listing.R
+++ b/R/get_league_listing.R
@@ -41,7 +41,7 @@ get_league_listing <- function(dota_id = 570, language = 'en', key = NULL) {
 
  #convert content to data.frame
  dota_result$content <-
-  do.call(rbind.data.frame, c(dota_result$content[[1]][[1]], stringsAsFactors = FALSE))
+  plyr::rbind.fill(lapply(dota_result$content[[1]][[1]], rbind.data.frame))
 
  #return
  dota_result


### PR DESCRIPTION
I'm using this package to develop a package that provides a easy way to collect the Dota2 data and store in MongoDB. But I need to force the function (core.R) because it return an error. So, what I did was return a NULL content instead of an error. So I can check the status code and verify if it was connection error, many requests etc ... and decides what to do...

The second change was the function get_leangue_listings that was has a problem with the do.call(rbind....) because the diferent number of columns... so I change to plyr::rbind.fill.

