### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -60,9 +60,10 @@ get_response <- function(dota_id, dota_api_method, dota_api_category, api_versio
                        api_version)
 
  #get response
- resp <- httr::GET(request_url,
-                   query = args,
-                   ua)
+resp <- httrr::RETRY(verb = "GET",
+                     url = request_url,
+                     query = args,
+                     ua)
 
  #get url
  url <- strsplit(resp$url, '\\?')[[1]][1]


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.